### PR TITLE
GHMC integrator adapted for NCMC

### DIFF
--- a/examples/run_sampler.py
+++ b/examples/run_sampler.py
@@ -86,7 +86,10 @@ if __name__ == "__main__":
         # Saving acceptance probability data:
         cnts = sampler.saltswap.getIdentityCounts()
         acc = sampler.saltswap.getAcceptanceProbability()
-        ghmc_acc = np.mean(np.array(sampler.saltswap.naccepted_ghmc))
+        if args.propagator == 'GHMC':
+            ghmc_acc = np.mean(np.array(sampler.saltswap.naccepted_ghmc))
+        else:
+            ghmc_acc = 0
         sampler.saltswap.naccepted_ghmc = []
         f = open(args.data, 'a')
         s = "{:4} {:5} {:5}   {:0.2f}      {:0.2f}   {:4}\n".format(i, cnts[0], cnts[1], round(acc,2), round(ghmc_acc,2), iter_time.seconds)
@@ -113,5 +116,7 @@ if __name__ == "__main__":
     tm = datetime.now() - startTime
 
     f = open(args.data, 'a')
-    s = "\nElapsed time in seconds = {:7}\n".format(tm.seconds)
+    s = "\nElapsed time in seconds = {:7}".format(tm.seconds)
+    f.write(s)
+    s = "\nNumber of NaNs = {:3}\n".format(sampler.saltswap.nan)
     f.write(s)

--- a/examples/run_sampler.py
+++ b/examples/run_sampler.py
@@ -113,5 +113,5 @@ if __name__ == "__main__":
     tm = datetime.now() - startTime
 
     f = open(args.data, 'a')
-    s = "\nElapsed time in seconds = {:7}".format(tm.seconds)
+    s = "\nElapsed time in seconds = {:7}\n".format(tm.seconds)
     f.write(s)

--- a/saltswap/integrators.py
+++ b/saltswap/integrators.py
@@ -7,11 +7,14 @@ kB = units.BOLTZMANN_CONSTANT_kB * units.AVOGADRO_CONSTANT_NA
 class GHMCIntegrator(mm.CustomIntegrator):
 
     """
-    Generalized hybrid Monte Carlo (GHMC) integrator.
+
+    This generalized hybrid Monte Carlo (GHMC) integrator is a modification of the GHMC integrator found
+    here https://github.com/choderalab/openmmtools. Multiple steps can be taken per integrator.step() in order to save
+    the potential energy before the steps were made.
 
     """
 
-    def __init__(self, temperature=298.0 * simtk.unit.kelvin, collision_rate=1.0 / simtk.unit.picoseconds, timestep=1.0 * simtk.unit.femtoseconds, nsteps=5):
+    def __init__(self, temperature=298.0 * simtk.unit.kelvin, collision_rate=1.0 / simtk.unit.picoseconds, timestep=1.0 * simtk.unit.femtoseconds, nsteps=1):
         """
         Create a generalized hybrid Monte Carlo (GHMC) integrator.
 
@@ -23,14 +26,15 @@ class GHMCIntegrator(mm.CustomIntegrator):
            The collision rate.
         timestep : simtk.unit.Quantity compatible with femtoseconds, default: 1.0*unit.femtoseconds
            The integration timestep.
+        nsteps : int
+           The number of steps to take per integrator.step()
 
         Notes
         -----
-        This integrator is equivalent to a Langevin integrator in the velocity Verlet discretization with a
+        It is equivalent to a Langevin integrator in the velocity Verlet discretization with a
         Metrpolization step to ensure sampling from the appropriate distribution.
 
-        Additional global variables 'ntrials' and  'naccept' keep track of how many trials have been attempted and
-        accepted, respectively.
+        An additional global variable 'potential_initial' records the potential energy before 'nsteps' have been taken.
 
         TODO
         ----

--- a/saltswap/mcmc_samplers.py
+++ b/saltswap/mcmc_samplers.py
@@ -66,7 +66,7 @@ class MCMCSampler(object):
         self.volsteps = volsteps
         self.saltsteps = saltsteps
 
-        proplist = ['GHMC','velocityVerlet']
+        proplist = ['GHMC','GHMC_old','velocityVerlet']
         if propagator not in proplist:
             raise Exception('NCMC propagator {0} not in supported list {1}'.format(propagator,proplist))
 

--- a/saltswap/mcmc_samplers.py
+++ b/saltswap/mcmc_samplers.py
@@ -77,7 +77,7 @@ class MCMCSampler(object):
             if propagator=='GHMC':
                 self.integrator.addIntegrator(GHMCIntegrator(temperature, 1/unit.picosecond, timestep, nsteps=nprop))
             elif propagator=='velocityVerlet':
-                self.integrator.addIntegrator(integrators.VelocityVerletIntegrator(0.1*unit.femtoseconds))
+                self.integrator.addIntegrator(integrators.VelocityVerletIntegrator(timestep*unit.femtoseconds))
             else:
                 raise Exception('NCMC propagator {0} not in supported list {1}'.format(propagator,proplist))
             self.integrator.setCurrentIntegrator(0)

--- a/saltswap/mcmc_samplers.py
+++ b/saltswap/mcmc_samplers.py
@@ -74,8 +74,10 @@ class MCMCSampler(object):
         if saltsteps !=0 and nprop != 0:
             self.integrator = openmm.CompoundIntegrator()
             self.integrator.addIntegrator(openmm.LangevinIntegrator(temperature, 1/unit.picosecond, 2.0*unit.femtoseconds))
-            if propagator=='GHMC':
+            if propagator == 'GHMC':
                 self.integrator.addIntegrator(GHMCIntegrator(temperature, 1/unit.picosecond, timestep, nsteps=nprop))
+            elif propagator == 'GHMC_old':
+                self.integrator.addIntegrator(integrators.GHMCIntegrator(temperature, 1/unit.picosecond, timestep))
             elif propagator=='velocityVerlet':
                 self.integrator.addIntegrator(integrators.VelocityVerletIntegrator(timestep*unit.femtoseconds))
             else:

--- a/saltswap/saltswap.py
+++ b/saltswap/saltswap.py
@@ -141,10 +141,10 @@ class SaltSwap(object):
 
         self.integrator = integrator
 
-        proplist = ['GHMC', 'velocityVerlet']
-        if propagator in ['GHMC', 'velocityVerlet']:
+        proplist = ['GHMC', 'GHMC_old', 'velocityVerlet']
+        if propagator in proplist:
             self.propagator = propagator
-        elif propagator not in ['GHMC', 'velocityVerlet'] and npert==0:
+        elif propagator not in proplist and npert==0:
             pass
         else:
             raise Exception('NCMC propagator {0} not in supported list {1}'.format(propagator, proplist))
@@ -515,8 +515,8 @@ class SaltSwap(object):
 
         Returns
         -------
-        work: simtk.unit
-            The work for appropriate for the stated propagator
+        work: float
+            The work for appropriate for the stated propagator in units of KT.
 
         """
         self.integrator.setCurrentIntegrator(1)

--- a/saltswap/saltswap.py
+++ b/saltswap/saltswap.py
@@ -260,12 +260,11 @@ class SaltSwap(object):
                     [charge, sigma, epsilon] = self.forces_to_update.getParticleParameters(atm.index)
                     parameters = {'charge': strip_in_unit_system(charge), 'sigma': strip_in_unit_system(sigma), 'epsilon': strip_in_unit_system(epsilon)}
                     param_list.append(parameters)
-                    #if self.debug: print('retrieveResidueParameters: %s : %s' % (resname, str(parameters)))
                 return param_list
         raise Exception("resname '%s' not found in topology" % resname)
 
     def initializeIonParameters(self,ion_name,ion_params=None):
-        '''
+        """
         Initialize the set of ion non-bonded parameters so that they match the number of atoms of the water model.
 
         Parameters
@@ -278,7 +277,7 @@ class SaltSwap(object):
             NonbondedForce parameter dict ('charge', 'sigma', 'epsilon') for ion.
         Returns
         -------
-        '''
+        """
 
         # Creating a list of non-bonded parameters that matches the size of the water model.
         num_wat_atoms = len(self.water_parameters)
@@ -321,11 +320,6 @@ class SaltSwap(object):
         -------
         water_residues : list of simtk.openmm.app.Residue
             Water residues.
-
-        TODO
-        ----
-        * Can this feature be added to simt.openmm.app.Topology?
-
         """
         target_residues = list()
         for residue in topology.residues():
@@ -336,7 +330,7 @@ class SaltSwap(object):
         return target_residues
 
     def initializeStateVector(self):
-        '''
+        """
         Stores the identity of the mutabable residues in a numpy array for efficient seaching and updating of
         residue identies.
 
@@ -345,7 +339,7 @@ class SaltSwap(object):
         stateVector : numpy array
             Array of 0s, 1s, and 2s to indicate water, sodium, and chlorine.
 
-        '''
+        """
         names = [res.name for res in self.mutable_residues]
         stateVector = np.zeros(len(names))
         for i in range(len(names)):
@@ -485,7 +479,7 @@ class SaltSwap(object):
         else:
             # Reject :(
             # Revert parameters to their previous value
-            self.updateForces(mode_backward,change_indices,stage=0)
+            self.updateForces(mode_backward,change_indices,stage=self.npert-1)
             #self.updateForces_fractional(mode_backward,change_indices,fraction=1.0)
             self.forces_to_update.updateParametersInContext(context)
             if self.nprop > 0:
@@ -557,10 +551,9 @@ class SaltSwap(object):
                 pot_final = ghmc.getGlobalVariableByName('potential_initial')
                 # Update the accumulated work
                 work += (pot_final - pot_initial)/self.kT_unitless
+            self.naccepted_ghmc.append(ghmc.getGlobalVariableByName('naccept')/ghmc.getGlobalVariableByName('ntrials'))
         else:
             raise Exception('Propagator "{0}" not recognized'.format(propagator))
-
-        self.naccepted_ghmc.append(ghmc.getGlobalVariableByName('naccept')/ghmc.getGlobalVariableByName('ntrials'))
         self.integrator.setCurrentIntegrator(0)
 
         return work

--- a/tests/vV_minimal.py
+++ b/tests/vV_minimal.py
@@ -1,0 +1,100 @@
+from simtk import openmm, unit
+from simtk.openmm import app
+from openmmtools import integrators
+from openmmtools.testsystems import WaterBox
+
+import sys
+sys.path.append("/Users/rossg/Work/saltswap/saltswap")
+
+size = 25.0*unit.angstrom     # The length of the edges of the water box.
+temperature = 300*unit.kelvin
+pressure = 1*unit.atmospheres
+wbox = WaterBox(box_edge=size,nonbondedMethod=app.PME,cutoff=9*unit.angstrom,ewaldErrorTolerance=1E-6)
+
+compound = True
+if compound == True:
+    integrator = openmm.CompoundIntegrator()
+    integrator.addIntegrator(openmm.LangevinIntegrator(temperature, 1.0/unit.picoseconds, 2.0*unit.femtoseconds))
+    integrator.addIntegrator(integrators.VelocityVerletIntegrator(timestep = 1*unit.femtoseconds))
+    vv = integrator.getIntegrator(1)
+else:
+    integrator = integrators.VelocityVerletIntegrator(timestep = 1*unit.femtoseconds)
+    vv = integrator
+
+context = openmm.Context(wbox.system, integrator)
+context.setPositions(wbox.positions)
+context.setVelocitiesToTemperature(temperature)
+
+if compound == True:
+    integrator.setCurrentIntegrator(0)
+    integrator.step(10)
+    integrator.setCurrentIntegrator(1)
+else:
+    vv.step(10)
+
+ntrials = 10
+force = wbox.system.getForce(2)       # Non-bonded force.
+
+# Turning the first water molecule into Na+. The second water molecule into Cl-
+run = True
+if run == True:
+    vv.step(1)     # propagation
+    for n in range(ntrials):
+        # Get the energy BEFORE the parameters are perturbed.
+        state = context.getState(getEnergy=True)
+        potential_old = state.getPotentialEnergy()/unit.kilojoule_per_mole
+        print('old',potential_old)
+         # Perturbation
+        fraction = 1 - float(n + 1)/ntrials
+
+        # Water 1 into cation
+        force.setParticleParameters(0,charge=-0.834*fraction + (1-fraction)*1.0,sigma=0.3150752406575124*fraction + (1-fraction)*0.2439281,epsilon=0.635968*fraction + (1-fraction)*0.0874393)
+        force.setParticleParameters(1,charge=0.417*fraction + (1-fraction)*0.0 ,sigma = 0.0, epsilon = 0.0)
+        force.setParticleParameters(2,charge=0.417*fraction,sigma=0,epsilon= 0.0)
+
+        # Water 2 into anion
+        force.setParticleParameters(3,charge=-0.834*fraction + (1-fraction)*(-1.0),sigma=0.3150752406575124*fraction + (1-fraction)*0.4477657,epsilon=0.635968*fraction + (1-fraction)*0.0355910)
+        force.setParticleParameters(4,charge=0.417*fraction + (1-fraction)*0.0 ,sigma = 0.0, epsilon = 0.0)
+        force.setParticleParameters(5,charge=0.417*fraction,sigma=0,epsilon= 0.0)
+
+        force.updateParametersInContext(context)
+
+        vv.step(1)
+
+        state = context.getState(getEnergy=True)
+        potential_new = state.getPotentialEnergy()/unit.kilojoule_per_mole
+        print('new',potential_new)
+    # Reseting the parameters
+    force.setParticleParameters(0,charge=-0.834,sigma=0.3150752406575124*fraction,epsilon=0.635968*fraction)
+    force.setParticleParameters(1,charge=0.417,sigma=0,epsilon=1)
+    force.setParticleParameters(2,charge=0.417,sigma=0,epsilon=1)
+    force.setParticleParameters(3,charge=-0.834,sigma=0.3150752406575124*fraction,epsilon=0.635968*fraction)
+    force.setParticleParameters(4,charge=0.417,sigma=0,epsilon=1)
+    force.setParticleParameters(5,charge=0.417,sigma=0,epsilon=1)
+    force.updateParametersInContext(context)
+
+# Decoupling the first water molecule
+if run == False:
+    vv.step(1)     # propagation
+    for n in range(ntrials):
+        # Get the energy BEFORE the parameters are perturbed.
+        state = context.getState(getEnergy=True)
+        potential_old = state.getPotentialEnergy()/unit.kilojoule_per_mole
+        print('old',potential_old)
+         # Perturbation
+        fraction = 1 - float(n + 1)/ntrials
+
+        force.setParticleParameters(0,charge=-0.834*fraction,sigma=0.3150752406575124*fraction,epsilon=0.635968*fraction)
+        force.setParticleParameters(1,charge=0.417*fraction,sigma=0,epsilon=1*fraction)
+        force.setParticleParameters(2,charge=0.417*fraction,sigma=0,epsilon=1*fraction)
+
+        force.updateParametersInContext(context)
+        # Get the energy AFTER the parameters have been perturbed.
+        state = context.getState(getEnergy=True)
+        potential_new = state.getPotentialEnergy()/unit.kilojoule_per_mole
+        vv.step(1)     # The 'old' energy for one step should be the energy immediately after the perturbation
+        print('new',potential_new)
+    force.setParticleParameters(0,charge=-0.834,sigma=0.3150752406575124*fraction,epsilon=0.635968*fraction)
+    force.setParticleParameters(1,charge=0.417,sigma=0,epsilon=1)
+    force.setParticleParameters(2,charge=0.417,sigma=0,epsilon=1)
+    force.updateParametersInContext(context)

--- a/tests/vV_minimal.py
+++ b/tests/vV_minimal.py
@@ -43,14 +43,15 @@ ntrials = 10
 force = wbox.system.getForce(2)       # Non-bonded force.
 
 # Turning the first water molecule into Na+. The second water molecule into Cl-
-run = False
+run = True
 if run == True:
+    print('Running saltswap test')
     vv.step(1)     # propagation
     for n in range(ntrials):
         # Get the energy BEFORE the parameters are perturbed.
         state = context.getState(getEnergy=True)
-        potential_old = state.getPotentialEnergy()/unit.kilojoule_per_mole
-        print('old',potential_old)
+        energy_old = (state.getPotentialEnergy() + state.getPotentialEnergy())/unit.kilojoule_per_mole
+        print('old',energy_old)
          # Perturbation
         fraction = 1 - float(n + 1)/ntrials
 
@@ -69,8 +70,8 @@ if run == True:
         vv.step(1)
 
         state = context.getState(getEnergy=True)
-        potential_new = state.getPotentialEnergy()/unit.kilojoule_per_mole
-        print('new',potential_new)
+        energy_new = (state.getPotentialEnergy() + state.getPotentialEnergy())/unit.kilojoule_per_mole
+        print('new',energy_new)
     # Reseting the parameters
     force.setParticleParameters(0,charge=-0.834,sigma=0.3150752406575124*fraction,epsilon=0.635968*fraction)
     force.setParticleParameters(1,charge=0.417,sigma=0,epsilon=1)
@@ -83,12 +84,13 @@ if run == True:
 # Decoupling the first water molecule
 run = True
 if run == True:
+    print('Running water decoupling test')
     vv.step(1)     # propagation
     for n in range(ntrials):
         # Get the energy BEFORE the parameters are perturbed.
         state = context.getState(getEnergy=True)
-        potential_old = state.getPotentialEnergy()/unit.kilojoule_per_mole
-        print('old',potential_old)
+        energy_old = (state.getPotentialEnergy() + state.getPotentialEnergy())/unit.kilojoule_per_mole
+        print('old',energy_old)
          # Perturbation
         fraction = 1 - float(n + 1)/ntrials
 
@@ -99,8 +101,8 @@ if run == True:
 
         vv.step(1)
         state = context.getState(getEnergy=True)
-        potential_new = state.getPotentialEnergy()/unit.kilojoule_per_mole
-        print('new',potential_new)
+        state = context.getState(getEnergy=True)
+        energy_new = (state.getPotentialEnergy() + state.getPotentialEnergy())/unit.kilojoule_per_mole
     force.setParticleParameters(0,charge=-0.834,sigma=0.3150752406575124*fraction,epsilon=0.635968*fraction)
     force.setParticleParameters(1,charge=0.417,sigma=0,epsilon=1)
     force.setParticleParameters(2,charge=0.417,sigma=0,epsilon=1)


### PR DESCRIPTION
To the GHMC integrator from `openmmtools` has been adapted to calculate the protocol work NCMC. An initial energy variable has been added and an inner loop over the number of propagation steps per NCMC perturbation step.

This PR also fixes a bug in which the non-bonded parameters were not being properly reset after an attempted was rejected.