### PR TITLE
New minimal timing test

### DIFF
--- a/Performance/MinimalTest2/README.md
+++ b/Performance/MinimalTest2/README.md
@@ -1,0 +1,12 @@
+# Simple timing test of integrators with and without switching off a water molecule in a water box
+
+To run:
+```bash
+# Make sure you are using an OpenMM 7.1.0 preview build
+conda install --yes -c omnia/labels/dev openmm
+# Install openmmtools to get access to testsystems
+conda install --yes -c omnia openmmtools
+# Run the timing comparison
+python minimal_test.py
+```
+

--- a/Performance/MinimalTest2/integrators.py
+++ b/Performance/MinimalTest2/integrators.py
@@ -1,0 +1,146 @@
+import numpy
+import simtk.unit
+import simtk.unit as units
+import simtk.openmm as mm
+kB = units.BOLTZMANN_CONSTANT_kB * units.AVOGADRO_CONSTANT_NA
+
+class GHMCIntegrator(mm.CustomIntegrator):
+
+    """
+
+    This generalized hybrid Monte Carlo (GHMC) integrator is a modification of the GHMC integrator found
+    here https://github.com/choderalab/openmmtools. Multiple steps can be taken per integrator.step() in order to save
+    the potential energy before the steps were made.
+
+    """
+
+    def __init__(self, temperature=298.0 * simtk.unit.kelvin, collision_rate=1.0 / simtk.unit.picoseconds, timestep=1.0 * simtk.unit.femtoseconds, nsteps=1):
+        """
+        Create a generalized hybrid Monte Carlo (GHMC) integrator.
+
+        Parameters
+        ----------
+        temperature : simtk.unit.Quantity compatible with kelvin, default: 298*unit.kelvin
+           The temperature.
+        collision_rate : simtk.unit.Quantity compatible with 1/picoseconds, default: 91.0/unit.picoseconds
+           The collision rate.
+        timestep : simtk.unit.Quantity compatible with femtoseconds, default: 1.0*unit.femtoseconds
+           The integration timestep.
+        nsteps : int
+           The number of steps to take per integrator.step()
+
+        Notes
+        -----
+        It is equivalent to a Langevin integrator in the velocity Verlet discretization with a
+        Metrpolization step to ensure sampling from the appropriate distribution.
+
+        An additional global variable 'potential_initial' records the potential energy before 'nsteps' have been taken.
+
+        Example
+        -------
+
+        Create a GHMC integrator.
+
+        >>> temperature = 298.0 * simtk.unit.kelvin
+        >>> collision_rate = 91.0 / simtk.unit.picoseconds
+        >>> timestep = 1.0 * simtk.unit.femtoseconds
+        >>> integrator = GHMCIntegrator(temperature, collision_rate, timestep)
+
+        References
+        ----------
+        Lelievre T, Stoltz G, and Rousset M. Free Energy Computations: A Mathematical Perspective
+        http://www.amazon.com/Free-Energy-Computations-Mathematical-Perspective/dp/1848162472
+
+        """
+        # Initialize constants.
+        kT = kB * temperature
+        gamma = collision_rate
+
+        # Create a new custom integrator.
+        super(GHMCIntegrator, self).__init__(timestep)
+
+        #
+        # Integrator initialization.
+        #
+        self.addGlobalVariable("kT", kT)  # thermal energy
+        self.addGlobalVariable("b", numpy.exp(-gamma * timestep))  # velocity mixing parameter
+        self.addPerDofVariable("sigma", 0) # velocity standard deviation
+        self.addGlobalVariable("ke", 0)  # kinetic energy
+        self.addPerDofVariable("vold", 0)  # old velocities
+        self.addPerDofVariable("xold", 0)  # old positions
+        self.addGlobalVariable("Eold", 0)  # old energy
+        self.addGlobalVariable("Enew", 0)  # new energy
+        self.addGlobalVariable("potential_initial", 0)  # initial potential energy
+        self.addGlobalVariable("potential_old", 0)  # old potential energy
+        self.addGlobalVariable("potential_new", 0)  # new potential energy
+        self.addGlobalVariable("work", 0)
+        self.addGlobalVariable("accept", 0)  # accept or reject
+        self.addGlobalVariable("naccept", 0)  # number accepted
+        self.addGlobalVariable("ntrials", 0)  # number of Metropolization trials
+        self.addPerDofVariable("x1", 0)  # position before application of constraints
+        self.addGlobalVariable("step", 0) # variable to keep track of number of propagation steps
+        self.addGlobalVariable("nsteps", nsteps)  # The number of iterations per integrator.step(1).
+        #
+        # Initialization.
+        #
+        self.beginIfBlock("ntrials = 0")
+        self.addComputePerDof("sigma", "sqrt(kT/m)")
+        self.addComputeGlobal("work", "0.0")
+        self.addConstrainPositions()
+        self.addConstrainVelocities()
+        self.addComputeGlobal("potential_new", "energy")
+        self.endBlock()
+
+        #
+        # Allow context updating here.
+        #
+        self.addUpdateContextState()
+
+        self.addComputeGlobal("potential_initial", "energy")
+        self.addComputeGlobal("step", "0")
+        self.addComputeGlobal("work", "work + (potential_initial - potential_new)")
+        if True:
+            self.beginWhileBlock("step < nsteps")
+            #
+            # Velocity randomization
+            #
+            self.addComputePerDof("v", "sqrt(b)*v + sqrt(1-b)*sigma*gaussian")
+            self.addConstrainVelocities()
+
+            # Compute initial total energy
+            self.addComputeSum("ke", "0.5*m*v*v")
+            self.addComputeGlobal("potential_old", "energy")
+            self.addComputeGlobal("Eold", "ke + potential_old")
+            self.addComputePerDof("xold", "x")
+            self.addComputePerDof("vold", "v")
+            # Velocity Verlet step
+            self.addComputePerDof("v", "v + 0.5*dt*f/m")
+            self.addComputePerDof("x", "x + v*dt")
+            self.addComputePerDof("x1", "x")
+            self.addConstrainPositions()
+            self.addComputePerDof("v", "v + 0.5*dt*f/m + (x-x1)/dt")
+            self.addConstrainVelocities()
+            # Compute final total energy
+            self.addComputeSum("ke", "0.5*m*v*v")
+            self.addComputeGlobal("potential_new", "energy")
+            self.addComputeGlobal("Enew", "ke + potential_new")
+            # Accept/reject, ensuring rejection if energy is NaN
+            self.addComputeGlobal("accept", "step(exp(-(Enew-Eold)/kT) - uniform)")
+            self.beginIfBlock("accept != 1")
+            self.addComputePerDof("x", "xold")
+            self.addComputePerDof("v", "-vold")
+            self.addComputeGlobal("potential_new", "potential_old")
+            self.endBlock()
+            #
+            # Velocity randomization
+            #
+            self.addComputePerDof("v", "sqrt(b)*v + sqrt(1-b)*sigma*gaussian")
+            self.addConstrainVelocities()
+            #
+            # Accumulate statistics.
+            #
+            self.addComputeGlobal("naccept", "naccept + accept")
+            self.addComputeGlobal("ntrials", "ntrials + 1")
+
+            self.addComputeGlobal("step", "step+1")
+            self.endBlock()

--- a/Performance/MinimalTest2/minimal_test.py
+++ b/Performance/MinimalTest2/minimal_test.py
@@ -33,7 +33,7 @@ def create_context(integrator):
     integrator.step(500)
     return context
 
-format = '%-64s: %8.3f s for %8d steps (%8.3f ps) : %8.3f ms / step : %5.3f x'
+format = '%-64s: %8.3f s for %8d steps (%8.3f ps) : %8.3f ms / step : %7.3f x'
 
 # Time VerletIntegrator without switching
 integrator = VerletIntegrator(timestep)

--- a/Performance/MinimalTest2/minimal_test.py
+++ b/Performance/MinimalTest2/minimal_test.py
@@ -7,7 +7,7 @@ from integrators import GHMCIntegrator
 
 platform = openmm.Platform.getPlatformByName('OpenCL')
 properties = {'Precision': 'mixed'}
-box_edge = 10.0 * unit.angstrom
+box_edge = 20.0 * unit.angstrom
 wbox = WaterBox(box_edge=box_edge, cutoff=box_edge / 2.05, nonbondedMethod=app.PME)
 force = wbox.system.getForce(2) # NonbondedForce
 nsteps = 50000 # number of switching steps
@@ -25,11 +25,11 @@ def create_context(integrator):
     context.setPositions(wbox.positions)
     context.setVelocitiesToTemperature(300*unit.kelvin)
     set_lambda(context, 1.0)
-    integrator.step(100)
+    integrator.step(500)
     return context
 
 print('System has %d particles' % wbox.system.getNumParticles())
-format = '%64s: %8.3f s for %8d steps (%8.3f ps) : %8.3f ms / step'
+format = '%64s: %8.3f s for %8d steps (%8.3f ps) : %8.3f ms / step : %5.3f x'
 
 # Time LangevinIntegrator without switching
 integrator = LangevinIntegrator(temperature, collision_rate, timestep)
@@ -38,8 +38,9 @@ initial_time = time.time()
 for step in range(nsteps):
     integrator.step(1)
 elapsed_time = time.time() - initial_time
+baseline = elapsed_time
 del context, integrator
-print(format % ('LangevinIntegrator', elapsed_time, nsteps, nsteps*timestep/unit.picoseconds, 1000*elapsed_time/float(nsteps)))
+print(format % ('LangevinIntegrator', elapsed_time, nsteps, nsteps*timestep/unit.picoseconds, 1000*elapsed_time/float(nsteps), elapsed_time/baseline))
 
 # Time LangevinIntegrator with switching
 integrator = LangevinIntegrator(temperature, collision_rate, timestep)
@@ -50,7 +51,7 @@ for step in range(nsteps):
     integrator.step(1)
 elapsed_time = time.time() - initial_time
 del context, integrator
-print(format % ('LangevinIntegrator with updateParametersInContext', elapsed_time, nsteps, nsteps*timestep/unit.picoseconds, 1000*elapsed_time/float(nsteps)))
+print(format % ('LangevinIntegrator with updateParametersInContext', elapsed_time, nsteps, nsteps*timestep/unit.picoseconds, 1000*elapsed_time/float(nsteps), elapsed_time/baseline))
 
 # Time GHMCIntegrator without switching
 integrator = GHMCIntegrator(temperature, collision_rate, timestep)
@@ -60,7 +61,7 @@ for step in range(nsteps):
     integrator.step(1)
 elapsed_time = time.time() - initial_time
 del context, integrator
-print(format % ('GHMCIntegratorIntegrator', elapsed_time, nsteps, nsteps*timestep/unit.picoseconds, 1000*elapsed_time/float(nsteps)))
+print(format % ('GHMCIntegratorIntegrator', elapsed_time, nsteps, nsteps*timestep/unit.picoseconds, 1000*elapsed_time/float(nsteps), elapsed_time/baseline))
 
 # Time GHMCIntegrator with switching
 integrator = GHMCIntegrator(temperature, collision_rate, timestep)
@@ -71,4 +72,4 @@ for step in range(nsteps):
     integrator.step(1)
 elapsed_time = time.time() - initial_time
 del context, integrator
-print(format % ('GHMCIntegrator with updateParametersInContext', elapsed_time, nsteps, nsteps*timestep/unit.picoseconds, 1000*elapsed_time/float(nsteps)))
+print(format % ('GHMCIntegrator with updateParametersInContext', elapsed_time, nsteps, nsteps*timestep/unit.picoseconds, 1000*elapsed_time/float(nsteps), elapsed_time/baseline))

--- a/Performance/MinimalTest2/minimal_test.py
+++ b/Performance/MinimalTest2/minimal_test.py
@@ -1,0 +1,74 @@
+import time
+from simtk import openmm, unit
+from simtk.openmm import app
+from openmmtools.testsystems import WaterBox
+from simtk.openmm import LangevinIntegrator
+from integrators import GHMCIntegrator
+
+platform = openmm.Platform.getPlatformByName('OpenCL')
+properties = {'Precision': 'mixed'}
+box_edge = 10.0 * unit.angstrom
+wbox = WaterBox(box_edge=box_edge, cutoff=box_edge / 2.05, nonbondedMethod=app.PME)
+force = wbox.system.getForce(2) # NonbondedForce
+nsteps = 50000 # number of switching steps
+temperature = 300.0 * unit.kelvin
+collision_rate = 1.0 / unit.picoseconds
+timestep = 2.0 * unit.femtoseconds
+def set_lambda(context, lambda_value=1.0):
+    force.setParticleParameters(0,charge=-0.834*lambda_value,sigma=0.3150752406575124*lambda_value,epsilon=0.635968*lambda_value)
+    force.setParticleParameters(1,charge=0.417*lambda_value,sigma=0,epsilon=1*lambda_value)
+    force.setParticleParameters(2,charge=0.417*lambda_value,sigma=0,epsilon=1*lambda_value)
+    force.updateParametersInContext(context)
+
+def create_context(integrator):
+    context = openmm.Context(wbox.system, integrator, platform, properties)
+    context.setPositions(wbox.positions)
+    context.setVelocitiesToTemperature(300*unit.kelvin)
+    set_lambda(context, 1.0)
+    integrator.step(100)
+    return context
+
+print('System has %d particles' % wbox.system.getNumParticles())
+format = '%64s: %8.3f s for %8d steps (%8.3f ps) : %8.3f ms / step'
+
+# Time LangevinIntegrator without switching
+integrator = LangevinIntegrator(temperature, collision_rate, timestep)
+context = create_context(integrator)
+initial_time = time.time()
+for step in range(nsteps):
+    integrator.step(1)
+elapsed_time = time.time() - initial_time
+del context, integrator
+print(format % ('LangevinIntegrator', elapsed_time, nsteps, nsteps*timestep/unit.picoseconds, 1000*elapsed_time/float(nsteps)))
+
+# Time LangevinIntegrator with switching
+integrator = LangevinIntegrator(temperature, collision_rate, timestep)
+context = create_context(integrator)
+initial_time = time.time()
+for step in range(nsteps):
+    set_lambda(context, lambda_value=float(nsteps-step)/float(nsteps))
+    integrator.step(1)
+elapsed_time = time.time() - initial_time
+del context, integrator
+print(format % ('LangevinIntegrator with updateParametersInContext', elapsed_time, nsteps, nsteps*timestep/unit.picoseconds, 1000*elapsed_time/float(nsteps)))
+
+# Time GHMCIntegrator without switching
+integrator = GHMCIntegrator(temperature, collision_rate, timestep)
+context = create_context(integrator)
+initial_time = time.time()
+for step in range(nsteps):
+    integrator.step(1)
+elapsed_time = time.time() - initial_time
+del context, integrator
+print(format % ('GHMCIntegratorIntegrator', elapsed_time, nsteps, nsteps*timestep/unit.picoseconds, 1000*elapsed_time/float(nsteps)))
+
+# Time GHMCIntegrator with switching
+integrator = GHMCIntegrator(temperature, collision_rate, timestep)
+context = create_context(integrator)
+initial_time = time.time()
+for step in range(nsteps):
+    set_lambda(context, lambda_value=float(nsteps-step)/float(nsteps))
+    integrator.step(1)
+elapsed_time = time.time() - initial_time
+del context, integrator
+print(format % ('GHMCIntegrator with updateParametersInContext', elapsed_time, nsteps, nsteps*timestep/unit.picoseconds, 1000*elapsed_time/float(nsteps)))

--- a/Performance/MinimalTest2/minimal_test.py
+++ b/Performance/MinimalTest2/minimal_test.py
@@ -2,22 +2,25 @@ import time
 from simtk import openmm, unit
 from simtk.openmm import app
 from openmmtools.testsystems import WaterBox
-from simtk.openmm import LangevinIntegrator
+from simtk.openmm import VerletIntegrator, LangevinIntegrator
 from integrators import GHMCIntegrator
 
 platform = openmm.Platform.getPlatformByName('OpenCL')
 properties = {'Precision': 'mixed'}
-box_edge = 20.0 * unit.angstrom
+box_edge = 10.0 * unit.angstrom
 wbox = WaterBox(box_edge=box_edge, cutoff=box_edge / 2.05, nonbondedMethod=app.PME)
 force = wbox.system.getForce(2) # NonbondedForce
 nsteps = 50000 # number of switching steps
 temperature = 300.0 * unit.kelvin
 collision_rate = 1.0 / unit.picoseconds
 timestep = 2.0 * unit.femtoseconds
+
+print('System has %d particles' % wbox.system.getNumParticles())
+
 def set_lambda(context, lambda_value=1.0):
-    force.setParticleParameters(0,charge=-0.834*lambda_value,sigma=0.3150752406575124*lambda_value,epsilon=0.635968*lambda_value)
-    force.setParticleParameters(1,charge=0.417*lambda_value,sigma=0,epsilon=1*lambda_value)
-    force.setParticleParameters(2,charge=0.417*lambda_value,sigma=0,epsilon=1*lambda_value)
+    force.setParticleParameters(0,charge=-0.834*lambda_value,sigma=0.3150752406575124,epsilon=0.635968*lambda_value)
+    force.setParticleParameters(1,charge=0.417*lambda_value,sigma=0.1,epsilon=0.0)
+    force.setParticleParameters(2,charge=0.417*lambda_value,sigma=0.1,epsilon=0.0)
     force.updateParametersInContext(context)
 
 def create_context(integrator):
@@ -28,8 +31,17 @@ def create_context(integrator):
     integrator.step(500)
     return context
 
-print('System has %d particles' % wbox.system.getNumParticles())
 format = '%64s: %8.3f s for %8d steps (%8.3f ps) : %8.3f ms / step : %5.3f x'
+
+# Time LangevinIntegrator without switching
+integrator = LangevinIntegrator(temperature, collision_rate, timestep)
+context = create_context(integrator)
+initial_time = time.time()
+integrator.step(nsteps)
+elapsed_time = time.time() - initial_time
+baseline = elapsed_time
+del context, integrator
+print(format % ('LangevinIntegrator.step(nsteps)', elapsed_time, nsteps, nsteps*timestep/unit.picoseconds, 1000*elapsed_time/float(nsteps), elapsed_time/baseline))
 
 # Time LangevinIntegrator without switching
 integrator = LangevinIntegrator(temperature, collision_rate, timestep)
@@ -38,9 +50,8 @@ initial_time = time.time()
 for step in range(nsteps):
     integrator.step(1)
 elapsed_time = time.time() - initial_time
-baseline = elapsed_time
 del context, integrator
-print(format % ('LangevinIntegrator', elapsed_time, nsteps, nsteps*timestep/unit.picoseconds, 1000*elapsed_time/float(nsteps), elapsed_time/baseline))
+print(format % ('LangevinIntegrator step(1) loop', elapsed_time, nsteps, nsteps*timestep/unit.picoseconds, 1000*elapsed_time/float(nsteps), elapsed_time/baseline))
 
 # Time LangevinIntegrator with switching
 integrator = LangevinIntegrator(temperature, collision_rate, timestep)

--- a/Performance/MinimalTest2/minimal_test.py
+++ b/Performance/MinimalTest2/minimal_test.py
@@ -6,6 +6,7 @@ from simtk.openmm import VerletIntegrator, LangevinIntegrator
 from integrators import GHMCIntegrator
 
 platform = openmm.Platform.getPlatformByName('OpenCL')
+#properties = {'Precision': 'mixed', 'OpenCLDisablePmeStream':'true'} # uncomment on GTX-1080s
 properties = {'Precision': 'mixed'}
 box_edge = 80.0 * unit.angstrom
 cutoff = 9.0 * unit.angstrom
@@ -32,7 +33,7 @@ def create_context(integrator):
     integrator.step(500)
     return context
 
-format = '%64s: %8.3f s for %8d steps (%8.3f ps) : %8.3f ms / step : %5.3f x'
+format = '%-64s: %8.3f s for %8d steps (%8.3f ps) : %8.3f ms / step : %5.3f x'
 
 # Time VerletIntegrator without switching
 integrator = VerletIntegrator(timestep)

--- a/Performance/MinimalTest2/minimal_test.py
+++ b/Performance/MinimalTest2/minimal_test.py
@@ -7,10 +7,10 @@ from integrators import GHMCIntegrator
 
 platform = openmm.Platform.getPlatformByName('OpenCL')
 properties = {'Precision': 'mixed'}
-box_edge = 10.0 * unit.angstrom
+box_edge = 80.0 * unit.angstrom
 wbox = WaterBox(box_edge=box_edge, cutoff=box_edge / 2.05, nonbondedMethod=app.PME)
 force = wbox.system.getForce(2) # NonbondedForce
-nsteps = 50000 # number of switching steps
+nsteps = 500 # number of switching steps
 temperature = 300.0 * unit.kelvin
 collision_rate = 1.0 / unit.picoseconds
 timestep = 2.0 * unit.femtoseconds
@@ -34,12 +34,21 @@ def create_context(integrator):
 format = '%64s: %8.3f s for %8d steps (%8.3f ps) : %8.3f ms / step : %5.3f x'
 
 # Time LangevinIntegrator without switching
-integrator = LangevinIntegrator(temperature, collision_rate, timestep)
+integrator = VerletIntegrator(timestep)
 context = create_context(integrator)
 initial_time = time.time()
 integrator.step(nsteps)
 elapsed_time = time.time() - initial_time
 baseline = elapsed_time
+del context, integrator
+print(format % ('VerletIntegrator.step(nsteps)', elapsed_time, nsteps, nsteps*timestep/unit.picoseconds, 1000*elapsed_time/float(nsteps), elapsed_time/baseline))
+
+# Time LangevinIntegrator without switching
+integrator = LangevinIntegrator(temperature, collision_rate, timestep)
+context = create_context(integrator)
+initial_time = time.time()
+integrator.step(nsteps)
+elapsed_time = time.time() - initial_time
 del context, integrator
 print(format % ('LangevinIntegrator.step(nsteps)', elapsed_time, nsteps, nsteps*timestep/unit.picoseconds, 1000*elapsed_time/float(nsteps), elapsed_time/baseline))
 

--- a/Performance/README.md
+++ b/Performance/README.md
@@ -1,2 +1,6 @@
 ## Directories used for testing the performance of SaltSwap
 ** FOR DEVELOPMENT AND TESTING ONLY **
+
+## Manifest
+
+* `MinimalTest2/` - timing comparison of LangevinIntegrator and GHMCIntegrator with and without updating switching water parameters with `updateParametersInContext`


### PR DESCRIPTION
This implements the minimal timing test @gregoryross and I discussed today. Tagging @bas-rustenburg as well.

It's based on the (really excellent!) [`Performance/MinimalTest/minimal_test.py`](https://github.com/gregoryross/openmm-saltswap/blob/master/Performance/MinimalTest/minimal_test.py) @gregoryross had already implemented.

The platform, precision, and timestep can be adjusted. Currently, it uses `OpenCL`, `mixed` precision, and a `2*unit.femtoseconds` timestep.

Sample output on a GTX-TITAN on tiny waterbox (`box_edge = 10*unit.angstrom`):
```
System has 96 particles
                                 LangevinIntegrator.step(nsteps):   18.554 s for    50000 steps ( 100.000 ps) :    0.371 ms / step : 1.000 x
                                 LangevinIntegrator step(1) loop:   19.377 s for    50000 steps ( 100.000 ps) :    0.388 ms / step : 1.044 x
               LangevinIntegrator with updateParametersInContext:   28.786 s for    50000 steps ( 100.000 ps) :    0.576 ms / step : 1.551 x
                                        GHMCIntegratorIntegrator:   46.808 s for    50000 steps ( 100.000 ps) :    0.936 ms / step : 2.523 x
                   GHMCIntegrator with updateParametersInContext:   85.851 s for    50000 steps ( 100.000 ps) :    1.717 ms / step : 4.627 x
```
On a larger waterbox (`box_edge = 20*unit.angstrom`):
```
System has 774 particles
                                 LangevinIntegrator.step(nsteps):   21.238 s for    50000 steps ( 100.000 ps) :    0.425 ms / step : 1.000 x
                                 LangevinIntegrator step(1) loop:   21.117 s for    50000 steps ( 100.000 ps) :    0.422 ms / step : 0.994 x
               LangevinIntegrator with updateParametersInContext:   54.772 s for    50000 steps ( 100.000 ps) :    1.095 ms / step : 2.579 x
                                        GHMCIntegratorIntegrator:   52.569 s for    50000 steps ( 100.000 ps) :    1.051 ms / step : 2.475 x
                   GHMCIntegrator with updateParametersInContext:  118.037 s for    50000 steps ( 100.000 ps) :    2.361 ms / step : 5.558 x
```
`box_edge = 40*unit.angstrom`:
```
System has 6282 particles
                                 LangevinIntegrator.step(nsteps):   79.005 s for    50000 steps ( 100.000 ps) :    1.580 ms / step : 1.000 x
                                 LangevinIntegrator step(1) loop:   82.699 s for    50000 steps ( 100.000 ps) :    1.654 ms / step : 1.047 x
               LangevinIntegrator with updateParametersInContext:  270.050 s for    50000 steps ( 100.000 ps) :    5.401 ms / step : 3.418 x
                                        GHMCIntegratorIntegrator:  135.626 s for    50000 steps ( 100.000 ps) :    2.713 ms / step : 1.717 x
                   GHMCIntegrator with updateParametersInContext:  424.997 s for    50000 steps ( 100.000 ps) :    8.500 ms / step : 5.379 x
```